### PR TITLE
Update Robot.java to import BuiltIn

### DIFF
--- a/src/main/java/com/github/hi_fi/httprequestlibrary/utils/Robot.java
+++ b/src/main/java/com/github/hi_fi/httprequestlibrary/utils/Robot.java
@@ -91,6 +91,7 @@ public class Robot {
         protected PythonInterpreter initialValue() {
             PythonInterpreter pythonInterpreter = new PythonInterpreter();
             pythonInterpreter.exec("from robot.api import logger");
+            pythonInterpreter.exec("from robot.libraries.BuiltIn import BuiltIn");
             return pythonInterpreter;
         }
     };


### PR DESCRIPTION
Without importing BuiltIn, below error thrown for Robot framework 3.1.2
          "NameError: name 'BuiltIn' is not defined"